### PR TITLE
Adjust volume naming

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ hcloud__server_firewalls:
 hcloud__server_user_data: ""
 hcloud__server_volumes: []
 # hcloud__server_volumes:
-#   - name: vol1
+#   - name: "{{ inventory_hostname_short }}-vol1"
 #     size: 10
 
 hcloud__server_force: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: Ensure volume is created and formatted
   hetzner.hcloud.hcloud_volume:
-    name: "{{ hcloud__server_name }}-{{ item.name }}"
+    name: "{{ item.name }}"
     server: "{{ hcloud__server_name }}"
     automount: true
     format: "{{ item.format | default('ext4') }}"


### PR DESCRIPTION
It should be possible to name volumes without the server hostname prefix. This PR removes it from the task. This way, it's still possible to add the hostname prefix manually, but also possible to omit it. On top of that, this change is inline with the README description, which implies that the prefix needs to be added manually. The volume example in vars file was changed to include the hostname prefix, just like in the README description.